### PR TITLE
Fix tag url

### DIFF
--- a/__tests__/utils.spec.js
+++ b/__tests__/utils.spec.js
@@ -35,7 +35,7 @@ describe('Utils', () => {
 
         expect(attachments[0].fields.find(a => a.title === 'Action')).toEqual({
           title: 'Action',
-          value: `<https://github.com/Discontract/github-action-slack-notify-deployment/commit/abc123/checks | CI>`,
+          value: `<https://github.com/Discontract/github-action-slack-notify-deployment/tree/abc123/checks | CI>`,
           short: true,
         });
       });
@@ -55,7 +55,7 @@ describe('Utils', () => {
 
         expect(attachments[0].fields.find(a => a.title === 'Branch')).toEqual({
           title: 'Branch',
-          value: `<https://github.com/Discontract/github-action-slack-notify-deployment/commit/abc123 | my-branch>`,
+          value: `<https://github.com/Discontract/github-action-slack-notify-deployment/tree/abc123 | my-branch>`,
           short: true,
         });
       });
@@ -67,7 +67,7 @@ describe('Utils', () => {
 
         expect(attachments[0].fields.find(a => a.title === 'Action')).toEqual({
           title: 'Action',
-          value: `<https://github.com/Discontract/github-action-slack-notify-deployment/commit/xyz678/checks | CI>`,
+          value: `<https://github.com/Discontract/github-action-slack-notify-deployment/tree/xyz678/checks | CI>`,
           short: true,
         });
       });

--- a/src/utils.js
+++ b/src/utils.js
@@ -15,7 +15,7 @@ function buildSlackAttachments({ status, color, tag, projectName, actor, repoUrl
         },
         {
           title: 'Tag',
-          value: `<${repoUrl}/commit/${tag} | ${tag}>`,
+          value: `<${repoUrl}/tree/${tag} | ${tag}>`,
           short: true,
         },
         {


### PR DESCRIPTION
Url on github should be REPO/tree/TAG and not REPO/commit/TAG

## Purpose

## Important Changes

## Changelog

- [ ] I have updated `CHANGELOG.md` under "Unreleased" with the changes included in this PR.
